### PR TITLE
add current sourmash modules

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -3,7 +3,7 @@ name: nf-core branch protection
 # It fails when someone tries to make a PR against the nf-core `master` branch instead of `dev`
 on:
   pull_request_target:
-    branches: [master]
+    branches: [main]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: nf-core CI
 on:
   push:
     branches:
-      - dev
+      - main
   pull_request:
   release:
     types: [published]

--- a/conf/test.config
+++ b/conf/test.config
@@ -22,7 +22,7 @@ params {
     // Input data
     // TODO nf-core: Specify the paths to your test data on nf-core/test-datasets
     // TODO nf-core: Give any required params for the test so that command line flags are not needed
-    input  = 'https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/samplesheet/samplesheet_test_illumina_amplicon.csv'
+    input  = 'https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/samplesheet/samplesheet_test_illumina_sispa.csv'
 
     // Fasta references
     fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/genome/NC_045512.2/GCF_009858895.2_ASM985889v3_genomic.200409.fna.gz'

--- a/modules.json
+++ b/modules.json
@@ -16,6 +16,14 @@
                     "multiqc": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905"
+                    },
+                    "sourmash/gather": {
+                        "branch": "master",
+                        "git_sha": "6879511dca37de3835867e2ee0f61cfcdbe376f2"
+                    },
+                    "sourmash/sketch": {
+                        "branch": "master",
+                        "git_sha": "80650e386f6cdf4292a4f30615a5a7ac131ae9d9"
                     }
                 }
             }

--- a/modules/nf-core/sourmash/gather/main.nf
+++ b/modules/nf-core/sourmash/gather/main.nf
@@ -1,0 +1,53 @@
+process SOURMASH_GATHER {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda (params.enable_conda ? "bioconda::sourmash=4.5.0" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/sourmash:4.5.0--hdfd78af_0':
+        'quay.io/biocontainers/sourmash:4.5.0--hdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(signature)
+    path(database)
+    val save_unassigned
+    val save_matches_sig
+    val save_prefetch
+    val save_prefetch_csv
+
+    output:
+    tuple val(meta), path('*.csv.gz')             , optional:true, emit: result
+    tuple val(meta), path('*_unassigned.sig.zip') , optional:true, emit: unassigned
+    tuple val(meta), path('*_matches.sig.zip')    , optional:true, emit: matches
+    tuple val(meta), path('*_prefetch.sig.zip')   , optional:true, emit: prefetch
+    tuple val(meta), path('*_prefetch.csv.gz')    , optional:true, emit: prefetchcsv
+    path "versions.yml"                           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def unassigned  = save_unassigned   ? "--output-unassigned ${prefix}_unassigned.sig.zip" : ''
+    def matches     = save_matches_sig  ? "--save-matches ${prefix}_matches.sig.zip"         : ''
+    def prefetch    = save_prefetch     ? "--save-prefetch ${prefix}_prefetch.sig.zip"       : ''
+    def prefetchcsv = save_prefetch_csv ? "--save-prefetch-csv ${prefix}_prefetch.csv.gz"    : ''
+
+    """
+    sourmash gather \\
+        $args \\
+        --output ${prefix}.csv.gz \\
+        ${unassigned} \\
+        ${matches} \\
+        ${prefetch} \\
+        ${prefetchcsv} \\
+        ${signature} \\
+        ${database}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        sourmash: \$(echo \$(sourmash --version 2>&1) | sed 's/^sourmash //' )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/sourmash/gather/meta.yml
+++ b/modules/nf-core/sourmash/gather/meta.yml
@@ -1,0 +1,93 @@
+name: "sourmash_gather"
+description: Search a metagenome sourmash signature against one or many reference databases and return the minimum set of genomes that contain the k-mers in the metagenome.
+keywords:
+  - FracMinHash sketch
+  - signature
+  - kmer
+  - containment
+  - sourmash
+  - genomics
+  - metagenomics
+  - taxonomic classification
+  - taxonomic profiling
+tools:
+  - "sourmash":
+      description: Compute and compare FracMinHash signatures for DNA data sets.
+      homepage: https://sourmash.readthedocs.io/
+      documentation: https://sourmash.readthedocs.io/
+      tool_dev_url: https://github.com/sourmash-bio/sourmash
+      doi: "10.21105/joss.00027"
+      licence: ["BSD-3-clause"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - signature:
+      type: file
+      description: File containing signatures (hash sketches) of a sample
+      pattern: "*.{sig}"
+  - db:
+      type: file
+      description: Sourmash database (a list of signatures, SBTs, or signature zip files)
+  - save_unassigned:
+      type: boolean
+      description: |
+        If true, output will contain a file that is a sourmash signature containing the unassigned hashes from the query
+  - save_matches_sig:
+      type: boolean
+      description: |
+        If true, output will contain a file that is a sourmash signature composed of the FracMinHash sketches that were matched in the database and that matched the query
+  - save_prefetch:
+      type: boolean
+      description: |
+        If true, output will contain a file with all prefetch-matched signatures from the database
+  - save_prefetch_csv:
+      type: boolean
+      description: |
+        If true, output will contain a csv file with the names of all prefetch-matched signatures
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - result:
+      type: file
+      description: |
+        Table with signatures classified as belonging to any of the genomes
+        in the sourmash database(s).
+      pattern: "*{csv.gz}"
+  - matches:
+      type: file
+      description: |
+        A signature containing FracMinHash sketches of genomes
+        in the sourmash database.
+      pattern: "*{sig.zip}"
+  - unassigned:
+      type: file
+      description: |
+        A FracMinHash sketch containing hashes (k-mers) that did not match to any of the genomes
+        in the sourmash database(s).
+      pattern: "*{sig.zip}"
+  - prefetch:
+      type: file
+      description: |
+        All prefetch-matched signatures from the database.
+      pattern: "*{sig.zip}"
+  - prefetchcsv:
+      type: file
+      description: |
+        The names of all prefetch-matched signatures from the database in CSV format.
+      pattern: "*{csv.gz}"
+
+authors:
+  - "@vmikk"
+  - "@taylorreiter"

--- a/modules/nf-core/sourmash/sketch/main.nf
+++ b/modules/nf-core/sourmash/sketch/main.nf
@@ -1,0 +1,36 @@
+process SOURMASH_SKETCH {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda (params.enable_conda ? "bioconda::sourmash=4.5.0" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/sourmash:4.5.0--hdfd78af_0':
+        'quay.io/biocontainers/sourmash:4.5.0--hdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(sequence)
+
+    output:
+    tuple val(meta), path("*.sig"), emit: signatures
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    // required defaults for the tool to run, but can be overridden
+    def args = task.ext.args ?: "dna --param-string 'scaled=1000,k=21,k=31,k=51,abund'"
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    sourmash sketch \\
+        $args \\
+        --merge '${prefix}' \\
+        --output '${prefix}.sig' \\
+        $sequence
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        sourmash: \$(echo \$(sourmash --version 2>&1) | sed 's/^sourmash //' )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/sourmash/sketch/meta.yml
+++ b/modules/nf-core/sourmash/sketch/meta.yml
@@ -1,0 +1,47 @@
+name: sourmash_sketch
+description: Create a signature (a group of FracMinHash sketches) of a sequence using sourmash
+keywords:
+  - hash sketch
+  - sourmash
+  - genomics
+  - metagenomics
+  - taxonomic classification
+  - taxonomic profiling
+  - kmer
+tools:
+  - sourmash:
+      description: Compute and compare FracMinHash signatures for DNA and protein data sets.
+      homepage: https://sourmash.readthedocs.io/
+      documentation: https://sourmash.readthedocs.io/
+      tool_dev_url: https://github.com/sourmash-bio/sourmash
+      doi: "10.21105/joss.00027"
+      licence: ["BSD-3-clause"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - sequence:
+      type: file
+      description: FASTA or FASTQ file containing (genomic, transcriptomic, or proteomic) sequence data
+      pattern: "*.{fna,fa,fasta,fastq,fq,faa}.gz"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - signatures:
+      type: file
+      description: FracMinHash signature of the given sequence
+      pattern: "*.{sig}"
+
+authors:
+  - "@Midnighter"


### PR DESCRIPTION
This PR adds the two sourmash modules that are already in nf-core modules. I'll add sourmash compare and sourmash plot later once those are in nf-core.

I haven't written them into the workflow yet, just adding the modules here.

I also probably should have put the other two changes in a separate repo -- because i switched `main` to the default branch, I changed the github actions workflow to run with changes to main. and then i switched the test data set to one that actually runs -- the one that shipped lagged on one of the fastqc runs, and this one finishes in 2 minutes instead.

In future prs, I'll update the docs with in this repo and add the sourmash modules to workflows.