### PR TITLE
Turn the nf-core modules into a workflow: sourmash sketch & sourmash gather

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -37,5 +37,9 @@ process {
             pattern: '*_versions.yml'
         ]
     }
+   
+    withName: SOURMASH_GATHER {
+        ext.args = "-k 21"
+    }
 
 }

--- a/modules/local/download_sourmash_gather_dbs.nf
+++ b/modules/local/download_sourmash_gather_dbs.nf
@@ -1,0 +1,29 @@
+process DOWNLOAD_SOURMASH_GATHER_DBS {
+    tag "gatherdb"
+    label 'process_single'
+
+    conda (params.enable_conda ? "anaconda::wget=1.20.1" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/wget:1.20.1' :
+        'quay.io/biocontainers/wget:1.20.1' }"
+
+    input:
+
+    output:
+    path '*.zip'       , emit: zips // GTDB database
+    path '*.sig'       , emit: sig  // human siganture 
+    path "versions.yml", emit: versions
+
+    script: //
+    """
+    # download GTDB reps data base
+    wget -O gtdb-rs207.genomic-reps.dna.k21.zip https://osf.io/f2wzc/download
+    # download human signature
+    wget -O GCF_000001405.39_GRCh38.p13_genomic.sig https://osf.io/fxup3/download
+    
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        wget: \$(wget --version | grep '^GNU' | sed 's/GNU Wget //' | sed 's/ .*//')
+    END_VERSIONS
+    """
+}

--- a/workflows/seqqc.nf
+++ b/workflows/seqqc.nf
@@ -129,10 +129,10 @@ workflow SEQQC {
     //
     // MODULE: sourmash gather
     //
-    // ch_sourmash_gather_dbs = DOWNLOAD_SOURMASH_GATHER_DBS.out.sig
+    DOWNLOAD_SOURMASH_GATHER_DBS.out.zips.concat(DOWNLOAD_SOURMASH_GATHER_DBS.out.sig).set { ch_sourmash_gather_dbs } // create new channel combining two download sourmash gather dbs outputs
     SOURMASH_GATHER (
         SOURMASH_SKETCH.out.signatures,
-        DOWNLOAD_SOURMASH_GATHER_DBS.out.sig,
+        ch_sourmash_gather_dbs,
         [], // val save_unassigned
         [], // val save_matches_sig
         [], // val save_prefetch

--- a/workflows/seqqc.nf
+++ b/workflows/seqqc.nf
@@ -50,6 +50,8 @@ include { INPUT_CHECK } from '../subworkflows/local/input_check'
 //
 include { FASTQC                      } from '../modules/nf-core/fastqc/main'
 include { MULTIQC                     } from '../modules/nf-core/multiqc/main'
+include { SOURMASH_SKETCH             } from '../modules/nf-core/sourmash/sketch/main'
+include { SOURMASH_GATHER             } from '../modules/nf-core/sourmash/gather/main'
 include { CUSTOM_DUMPSOFTWAREVERSIONS } from '../modules/nf-core/custom/dumpsoftwareversions/main'
 
 /*
@@ -108,6 +110,14 @@ workflow SEQQC {
     )
     multiqc_report = MULTIQC.out.report.toList()
     ch_versions    = ch_versions.mix(MULTIQC.out.versions)
+
+    // 
+    // MODULE: sourmash sketch
+    //
+    SOURMASH_SKETCH (
+        INPUT_CHECK.out.reads
+    )
+    ch_versions = ch_versions.mix(SOURMASH_SKETCH.out.versions)
 }
 
 /*

--- a/workflows/seqqc.nf
+++ b/workflows/seqqc.nf
@@ -129,14 +129,14 @@ workflow SEQQC {
     //
     // MODULE: sourmash gather
     //
-    ch_sourmash_gather_dbs = concat(DOWNLOAD_SOURMASH_GATHER_DBS.out.zips, DOWNLOAD_SOURMASH_GATHER_DBS.out.sig)
+    // ch_sourmash_gather_dbs = DOWNLOAD_SOURMASH_GATHER_DBS.out.sig
     SOURMASH_GATHER (
         SOURMASH_SKETCH.out.signatures,
-        ch_sourmash_gather_dbs,
-        '', // val save_unassigned
-        '', // val save_matches_sig
-        '', // val save_prefetch
-        ''  // val save_prefetch_csv
+        DOWNLOAD_SOURMASH_GATHER_DBS.out.sig,
+        [], // val save_unassigned
+        [], // val save_matches_sig
+        [], // val save_prefetch
+        []  // val save_prefetch_csv
     )
     ch_versions = ch_versions.mix(SOURMASH_GATHER.out.versions)
 }


### PR DESCRIPTION
This PR integrates the sourmash sketch and sourmash gather modules into a DSL2 workflow, tacking on after fastqc and multiqc. I use the nf-core sketch and gather modules, and create my own module to download the GTDB reps and human (k = 21) databases/signatures. I hard coded this for now because these should be our defaults, but in the future it could be cool to parameterize the whole workflow on ksize if there's a need for that.

One thing I haven't figured out is how to make the contamination database small for test runs. Right now, I have it running against a human genome signature and all of GTDB reps. This is way to big for a test run. The test should just run against human. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/Arcadia-Science/seqqc/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
