### PR TITLE
add workflow for gather

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,5 @@ jobs:
           version: "${{ matrix.NXF_VER }}"
 
       - name: Run pipeline with test data
-        # TODO nf-core: You can customise CI pipeline run tests as required
-        # For example: adding multiple test runs with different parameters
-        # Remember that you can parallelise this by using strategy.matrix
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -1,20 +1,20 @@
 repository_type: pipeline
 lint:
   files_exist:
-  - CODE_OF_CONDUCT.md
-  - assets/nf-core-seqqc_logo_light.png
-  - docs/images/nf-core-seqqc_logo_light.png
-  - docs/images/nf-core-seqqc_logo_dark.png
-  - .github/ISSUE_TEMPLATE/config.yml
-  - .github/workflows/awstest.yml
-  - .github/workflows/awsfulltest.yml
-  - conf/igenomes.config
+    - CODE_OF_CONDUCT.md
+    - assets/nf-core-seqqc_logo_light.png
+    - docs/images/nf-core-seqqc_logo_light.png
+    - docs/images/nf-core-seqqc_logo_dark.png
+    - .github/ISSUE_TEMPLATE/config.yml
+    - .github/workflows/awstest.yml
+    - .github/workflows/awsfulltest.yml
+    - conf/igenomes.config
   nextflow_config:
-  - manifest.name
-  - manifest.homePage
+    - manifest.name
+    - manifest.homePage
   multiqc_config:
-  - report_comment
+    - report_comment
   readme:
-  - nextflow_badge
+    - nextflow_badge
   files_unchanged:
-  - .github/ISSUE_TEMPLATE/bug_report.yml
+    - .github/ISSUE_TEMPLATE/bug_report.yml

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -8,6 +8,7 @@ lint:
   - .github/ISSUE_TEMPLATE/config.yml
   - .github/workflows/awstest.yml
   - .github/workflows/awsfulltest.yml
+  - conf/igenomes.config
   nextflow_config:
   - manifest.name
   - manifest.homePage
@@ -15,3 +16,5 @@ lint:
   - report_comment
   readme:
   - nextflow_badge
+  files_unchanged:
+  - .github/ISSUE_TEMPLATE/bug_report.yml

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@ results/
 testing/
 testing*
 *.pyc
+outdir/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,16 @@ Initial release of Arcadia-Science/seqqc, created with the [nf-core](https://nf-
 
 ### `Added`
 
-* Local module to download sourmash GTDB database and human signature
-* Workflow to run sourmash gather to detect routine contamination
- 
+- Local module to download sourmash GTDB database and human signature
+- Workflow to run sourmash gather to detect routine contamination
+
 ### `Fixed`
 
 ### `Dependencies`
 
-* `fastqc=0.11.9`
-* `multiqc=1.13`
-* `sourmash=4.5.0`
-* `wget=1.20.1`
+- `fastqc=0.11.9`
+- `multiqc=1.13`
+- `sourmash=4.5.0`
+- `wget=1.20.1`
 
 ### `Deprecated`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,22 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.0dev - [date]
+## v1.0dev - November 2022
 
 Initial release of Arcadia-Science/seqqc, created with the [nf-core](https://nf-co.re/) template.
 
 ### `Added`
 
+* Local module to download sourmash GTDB database and human signature
+* Workflow to run sourmash gather to detect routine contamination
+ 
 ### `Fixed`
 
 ### `Dependencies`
+
+* `fastqc=0.11.9`
+* `multiqc=1.13`
+* `sourmash=4.5.0`
+* `wget=1.20.1`
 
 ### `Deprecated`

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -15,6 +15,9 @@
 - [MultiQC](https://pubmed.ncbi.nlm.nih.gov/27312411/)
   > Ewels P, Magnusson M, Lundin S, Käller M. MultiQC: summarize analysis results for multiple tools and samples in a single report. Bioinformatics. 2016 Oct 1;32(19):3047-8. doi: 10.1093/bioinformatics/btw354. Epub 2016 Jun 16. PubMed PMID: 27312411; PubMed Central PMCID: PMC5039924.
 
+- [Sourmash](https://joss.theoj.org/papers/10.21105/joss.00027)
+  > Brown CT, Irber L. Sourmash: a library for MinHash sketching of DNA. Journal of Open Source Software. 2016; 1(5):27. doi: 10.21105/joss.00027.
+
 ## Software packaging/containerisation tools
 
 - [Anaconda](https://anaconda.com)

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -13,6 +13,7 @@
 - [FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/)
 
 - [MultiQC](https://pubmed.ncbi.nlm.nih.gov/27312411/)
+
   > Ewels P, Magnusson M, Lundin S, Käller M. MultiQC: summarize analysis results for multiple tools and samples in a single report. Bioinformatics. 2016 Oct 1;32(19):3047-8. doi: 10.1093/bioinformatics/btw354. Epub 2016 Jun 16. PubMed PMID: 27312411; PubMed Central PMCID: PMC5039924.
 
 - [Sourmash](https://joss.theoj.org/papers/10.21105/joss.00027)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ On release, automated continuous integration tests run the pipeline on a full-si
 
 1. Read QC ([`FastQC`](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/))
 2. Present QC for raw reads ([`MultiQC`](http://multiqc.info/))
-3. Contamination detection using the [GTDB database](https://gtdb.ecogenomic.org/) and the human genome ([`sourmash`](https://sourmash.readthedocs.io))
+3. Contamination detection ([`sourmash`](https://sourmash.readthedocs.io))
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 ## Introduction
 
-<!-- TODO nf-core: Write a 1-2 sentence summary of what data the pipeline is for and what it does -->
-
-**Arcadia-Science/seqqc** is a bioinformatics best-practice analysis pipeline for Quality control for sequencing data.
+**Arcadia-Science/seqqc** is a bioinformatics best-practice analysis pipeline for quality control for sequencing data.
+The pipeline can be used on short or long read sequencing data (in FASTQ format) to identify common problems like the presence of adapters, high sequencing duplication rates, mislabelled samples, and contamination.
 
 The pipeline is built using [Nextflow](https://www.nextflow.io), a workflow tool to run tasks across multiple compute infrastructures in a very portable manner. It uses Docker/Singularity containers making installation trivial and results highly reproducible. The [Nextflow DSL2](https://www.nextflow.io/docs/latest/dsl2.html) implementation of this pipeline uses one container per process which makes it much easier to maintain and update software dependencies. Where possible, these processes have been submitted to and installed from [nf-core/modules](https://github.com/nf-core/modules) in order to make them available to all nf-core pipelines, and to everyone within the Nextflow community!
 
@@ -12,10 +11,9 @@ On release, automated continuous integration tests run the pipeline on a full-si
 
 ## Pipeline summary
 
-<!-- TODO nf-core: Fill in short bullet-pointed list of the default steps in the pipeline -->
-
 1. Read QC ([`FastQC`](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/))
 2. Present QC for raw reads ([`MultiQC`](http://multiqc.info/))
+3. Contamination detection using the [GTDB database](https://gtdb.ecogenomic.org/) and the human genome ([`sourmash`](https://sourmash.readthedocs.io))
 
 ## Quick Start
 
@@ -38,19 +36,13 @@ On release, automated continuous integration tests run the pipeline on a full-si
 
 4. Start running your own analysis!
 
-   <!-- TODO nf-core: Update the example "typical command" below used to run the pipeline -->
-
    ```bash
-   nextflow run Arcadia-Science/seqqc --input samplesheet.csv --outdir <OUTDIR> --genome GRCh37 -profile <docker/singularity/podman/shifter/charliecloud/conda/institute>
+   nextflow run Arcadia-Science/seqqc --input samplesheet.csv --outdir <OUTDIR> -profile <docker/singularity/podman/shifter/charliecloud/conda/institute>
    ```
 
 ## Credits
 
-Arcadia-Science/seqqc was originally written by Arcadia Science.
-
-We thank the following people for their extensive assistance in the development of this pipeline:
-
-<!-- TODO nf-core: If applicable, make list of people who have also contributed -->
+Arcadia-Science/seqqc was originally written by scientists at Arcadia Science.
 
 ## Contributions and Support
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -10,7 +10,6 @@
 
 process {
 
-    // TODO nf-core: Check the defaults for all processes
     cpus   = { check_max( 1    * task.attempt, 'cpus'   ) }
     memory = { check_max( 6.GB * task.attempt, 'memory' ) }
     time   = { check_max( 4.h  * task.attempt, 'time'   ) }
@@ -24,8 +23,6 @@ process {
     //        These labels are used and recognised by default in DSL2 files hosted on nf-core/modules.
     //        If possible, it would be nice to keep the same label naming convention when
     //        adding in your local modules too.
-    // TODO nf-core: Customise requirements for specific processes.
-    // See https://www.nextflow.io/docs/latest/config.html#config-process-selectors
     withLabel:process_single {
         cpus   = { check_max( 1                  , 'cpus'    ) }
         memory = { check_max( 6.GB * task.attempt, 'memory'  ) }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -38,4 +38,8 @@ process {
         ]
     }
 
+    withName: SOURMASH_GATHER {
+        ext.args = "-k 21"
+    }
+
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -20,10 +20,6 @@ params {
     max_time   = '6.h'
 
     // Input data
-    // TODO nf-core: Specify the paths to your test data on nf-core/test-datasets
     // TODO nf-core: Give any required params for the test so that command line flags are not needed
     input  = 'https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/samplesheet/samplesheet_test_illumina_sispa.csv'
-
-    // Fasta references
-    fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/genome/NC_045512.2/GCF_009858895.2_ASM985889v3_genomic.200409.fna.gz'
 }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -19,6 +19,4 @@ params {
     // TODO nf-core: Give any required params for the test so that command line flags are not needed
     input = 'https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/samplesheet/samplesheet_full_illumina_amplicon.csv'
 
-    // Fasta references
-    fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/genome/NC_045512.2/GCF_009858895.2_ASM985889v3_genomic.200409.fna.gz'
 }

--- a/lib/WorkflowMain.groovy
+++ b/lib/WorkflowMain.groovy
@@ -22,7 +22,7 @@ class WorkflowMain {
     // Print help to screen if required
     //
     public static String help(workflow, params, log) {
-        def command = "nextflow run ${workflow.manifest.name} --input samplesheet.csv --fasta reference.fa -profile docker"
+        def command = "nextflow run ${workflow.manifest.name} --input samplesheet.csv -profile docker"
         def help_string = ''
         help_string += NfcoreTemplate.logo(workflow, params.monochrome_logs)
         help_string += NfcoreSchema.paramsHelp(workflow, params, command)

--- a/lib/WorkflowSeqqc.groovy
+++ b/lib/WorkflowSeqqc.groovy
@@ -9,7 +9,7 @@ class WorkflowSeqqc {
     //
     // Check and validate parameters
     //
-    public static void initialise(params, log) { 
+    public static void initialise(params, log) {
 
     }
 

--- a/lib/WorkflowSeqqc.groovy
+++ b/lib/WorkflowSeqqc.groovy
@@ -9,8 +9,7 @@ class WorkflowSeqqc {
     //
     // Check and validate parameters
     //
-    public static void initialise(params, log) {
-        
+    public static void initialise(params, log) { 
 
     }
 

--- a/lib/WorkflowSeqqc.groovy
+++ b/lib/WorkflowSeqqc.groovy
@@ -12,10 +12,6 @@ class WorkflowSeqqc {
     public static void initialise(params, log) {
         
 
-        if (!params.fasta) {
-            log.error "Genome fasta file not specified with e.g. '--fasta genome.fa' or via a detectable config file."
-            System.exit(1)
-        }
     }
 
     //

--- a/modules/local/download_sourmash_gather_dbs.nf
+++ b/modules/local/download_sourmash_gather_dbs.nf
@@ -1,0 +1,29 @@
+process DOWNLOAD_SOURMASH_GATHER_DBS {
+    tag "gatherdb"
+    label 'process_single'
+
+    conda (params.enable_conda ? "anaconda::wget=1.20.1" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/wget:1.20.1' :
+        'quay.io/biocontainers/wget:1.20.1' }"
+
+    input:
+
+    output:
+    path '*.zip'       , emit: zips // GTDB database
+    path '*.sig'       , emit: sig  // human siganture 
+    path "versions.yml", emit: versions
+
+    script: //
+    """
+    # download GTDB reps data base
+    wget -O gtdb-rs207.genomic-reps.dna.k21.zip https://osf.io/f2wzc/download
+    # download human signature
+    wget -O GCF_000001405.39_GRCh38.p13_genomic.sig https://osf.io/fxup3/download
+    
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        wget: \$(wget --version | grep '^GNU' | sed 's/GNU Wget //' | sed 's/ .*//')
+    END_VERSIONS
+    """
+}

--- a/modules/local/download_sourmash_gather_dbs.nf
+++ b/modules/local/download_sourmash_gather_dbs.nf
@@ -16,7 +16,7 @@ process DOWNLOAD_SOURMASH_GATHER_DBS {
     script: //
     """
     # download contam db built by Arcadia-Science/seqqc-build-contam-db
-    wget -O contamdb.dna.k21.zip https://osf.io/ma8cf/download 
+    wget -O contamdb.dna.k21.zip https://osf.io/ma8cf/download
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/download_sourmash_gather_dbs.nf
+++ b/modules/local/download_sourmash_gather_dbs.nf
@@ -10,16 +10,13 @@ process DOWNLOAD_SOURMASH_GATHER_DBS {
     input:
 
     output:
-    path '*.zip'       , emit: zips // GTDB database
-    path '*.sig'       , emit: sig  // human siganture
+    path '*.zip'       , emit: zips // contam db
     path "versions.yml", emit: versions
 
     script: //
     """
-    # download GTDB reps data base
-    wget -O gtdb-rs207.genomic-reps.dna.k21.zip https://osf.io/f2wzc/download
-    # download human signature
-    wget -O GCF_000001405.39_GRCh38.p13_genomic.sig https://osf.io/fxup3/download
+    # download contam db built by Arcadia-Science/seqqc-build-contam-db
+    wget -O contamdb.dna.k21.zip https://osf.io/ma8cf/download 
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/download_sourmash_gather_dbs.nf
+++ b/modules/local/download_sourmash_gather_dbs.nf
@@ -11,7 +11,7 @@ process DOWNLOAD_SOURMASH_GATHER_DBS {
 
     output:
     path '*.zip'       , emit: zips // GTDB database
-    path '*.sig'       , emit: sig  // human siganture 
+    path '*.sig'       , emit: sig  // human siganture
     path "versions.yml", emit: versions
 
     script: //
@@ -20,7 +20,7 @@ process DOWNLOAD_SOURMASH_GATHER_DBS {
     wget -O gtdb-rs207.genomic-reps.dna.k21.zip https://osf.io/f2wzc/download
     # download human signature
     wget -O GCF_000001405.39_GRCh38.p13_genomic.sig https://osf.io/fxup3/download
-    
+
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         wget: \$(wget --version | grep '^GNU' | sed 's/GNU Wget //' | sed 's/ .*//')

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,10 +10,7 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": [
-                "input",
-                "outdir"
-            ],
+            "required": ["input", "outdir"],
             "properties": {
                 "input": {
                     "type": "string",
@@ -154,14 +151,7 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": [
-                        "symlink",
-                        "rellink",
-                        "link",
-                        "copy",
-                        "copyNoFollow",
-                        "move"
-                    ],
+                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
                     "hidden": true
                 },
                 "email_on_fail": {

--- a/workflows/seqqc.nf
+++ b/workflows/seqqc.nf
@@ -129,10 +129,9 @@ workflow SEQQC {
     //
     // MODULE: sourmash gather
     //
-    DOWNLOAD_SOURMASH_GATHER_DBS.out.zips.concat(DOWNLOAD_SOURMASH_GATHER_DBS.out.sig).set { ch_sourmash_gather_dbs } // create new channel combining two download sourmash gather dbs outputs
     SOURMASH_GATHER (
         SOURMASH_SKETCH.out.signatures,
-        ch_sourmash_gather_dbs,
+        DOWNLOAD_SOURMASH_GATHER_DBS.out.zips,
         [], // val save_unassigned
         [], // val save_matches_sig
         [], // val save_prefetch

--- a/workflows/seqqc.nf
+++ b/workflows/seqqc.nf
@@ -11,7 +11,7 @@ WorkflowSeqqc.initialise(params, log)
 
 // TODO nf-core: Add all file path parameters for the pipeline to the list below
 // Check input path parameters to see if they exist
-def checkPathParamList = [ params.input, params.multiqc_config, params.fasta ]
+def checkPathParamList = [ params.input, params.multiqc_config ]
 for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true) } }
 
 // Check mandatory parameters

--- a/workflows/seqqc.nf
+++ b/workflows/seqqc.nf
@@ -9,7 +9,6 @@ def summary_params = NfcoreSchema.paramsSummaryMap(workflow, params)
 // Validate input parameters
 WorkflowSeqqc.initialise(params, log)
 
-// TODO nf-core: Add all file path parameters for the pipeline to the list below
 // Check input path parameters to see if they exist
 def checkPathParamList = [ params.input, params.multiqc_config ]
 for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true) } }


### PR DESCRIPTION
This PR integrates the sourmash sketch and sourmash gather modules into a DSL2 workflow, tacking on after fastqc and multiqc. I use the nf-core sketch and gather modules, and create my own module to download the contamination database used by gather. I hard coded this for now because these should be our defaults, but in the future it could be cool to parameterize the whole workflow on ksize if there's a need for that.

~One thing I haven't figured out is how to make the contamination database small for test runs. Right now, I have it running against a human genome signature and all of GTDB reps. This is way to big for a test run. The test should just run against human.~ I solved this by actually just making a small contam db over here: https://github.com/Arcadia-Science/seqqc-build-contam-db

One unresolved thing from this PR -- right now, if there are no matches in the sample against the gather database, no csv is output. This could be ok, but I think it would be better to output an empty csv. I have an issue open here: https://github.com/sourmash-bio/sourmash/issues/2357. I think an empty csv would be better because then I could check its contents and explicitly write a report that summarizes that there is no contam.

This PR also does some cleanup that I found when writing this workflow -- sorry it makes it a bit scattered.

Some of the recommended to do items aren't one yet bc the pipeline isn't advance enough. I think that's ok and have crossed them out below.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/Arcadia-Science/seqqc/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] ~Usage Documentation in `docs/usage.md` is updated.~
- [ ] ~Output Documentation in `docs/output.md` is updated.~
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
