### PR TITLE
Add sourmash compare module to workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Initial release of Arcadia-Science/seqqc, created with the [nf-core](https://nf-
 
 - Local module to download sourmash GTDB database and human signature
 - Workflow to run sourmash gather to detect routine contamination
+- Workflow to run sourmash compare to determine sequence similarity between samples
 
 ### `Fixed`
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ On release, automated continuous integration tests run the pipeline on a full-si
 1. Read QC ([`FastQC`](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/))
 2. Present QC for raw reads ([`MultiQC`](http://multiqc.info/))
 3. Contamination detection ([`sourmash`](https://sourmash.readthedocs.io))
+4. Sample sequence similarity measurement ([`sourmash`](https://sourmash.readthedocs.io))
 
 ## Quick Start
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -42,4 +42,7 @@ process {
         ext.args = "-k 21"
     }
 
+    withName: SOURMASH_COMPARE {
+        ext.args = "-k 21"
+    }
 }

--- a/modules/local/download_sourmash_gather_dbs.nf
+++ b/modules/local/download_sourmash_gather_dbs.nf
@@ -17,7 +17,8 @@ process DOWNLOAD_SOURMASH_GATHER_DBS {
     script: //
     """
     # download GTDB reps data base
-    wget -O gtdb-rs207.genomic-reps.dna.k21.zip https://osf.io/f2wzc/download
+    # wget -O gtdb-rs207.genomic-reps.dna.k21.zip https://osf.io/f2wzc/download
+    touch gtdb-rs207.genomic-reps.dna.k21.zip
     # download human signature
     wget -O GCF_000001405.39_GRCh38.p13_genomic.sig https://osf.io/fxup3/download
     

--- a/modules/local/download_sourmash_gather_dbs.nf
+++ b/modules/local/download_sourmash_gather_dbs.nf
@@ -17,8 +17,7 @@ process DOWNLOAD_SOURMASH_GATHER_DBS {
     script: //
     """
     # download GTDB reps data base
-    # wget -O gtdb-rs207.genomic-reps.dna.k21.zip https://osf.io/f2wzc/download
-    touch gtdb-rs207.genomic-reps.dna.k21.zip
+    wget -O gtdb-rs207.genomic-reps.dna.k21.zip https://osf.io/f2wzc/download
     # download human signature
     wget -O GCF_000001405.39_GRCh38.p13_genomic.sig https://osf.io/fxup3/download
     


### PR DESCRIPTION
This PR adds the `sourmash compare` nf-core module to the workflow. `sourmash compare` produces a similarity matrix for samples. The output csv for test data looks like this:

```
SRR11140746_T1,SRR11140744_T1,SRR11140750_T1,SRR11140748_T1
1.0,0.8834790349528564,0.5829990462730297,0.835425267095806
0.8834790349528564,1.0,0.583235385680498,0.7689967443244281
0.5829990462730297,0.583235385680498,1.0,0.5812485624124768
0.835425267095806,0.7689967443244281,0.5812485624124768,1.0
```

~#8 should be merged to `dev` and this branch synced before this PR is evaluated~ done

The next step after this PR is integrating visualizations for the gather and compare outputs. After this PR is merged, I would be able to assess whether fastq files are high enough quality to post to the SRA, but I wouldn't expect anyone else to be able to yet bc there aren't enough docs or visualizations.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/Arcadia-Science/seqqc/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] ~Usage Documentation in `docs/usage.md` is updated.~
- [ ] ~Output Documentation in `docs/output.md` is updated.~
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
