### PR TITLE
Enable singularity 

### DIFF
--- a/modules/local/download_sourmash_gather_dbs.nf
+++ b/modules/local/download_sourmash_gather_dbs.nf
@@ -3,9 +3,10 @@ process DOWNLOAD_SOURMASH_GATHER_DBS {
     label 'process_single'
 
     conda "conda-forge::wget=1.20.1"
+    conda "bioconda::gnu-wget=1.18"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/wget:1.20.1' :
-        'quay.io/biocontainers/wget:1.20.1' }"
+        'https://depot.galaxyproject.org/singularity/gnu-wget:1.18--h60da905_7' :
+        'quay.io/biocontainers/gnu-wget:1.18--h60da905_7' }"
 
     input:
 

--- a/modules/local/nf-core-modified/multiqc/main.nf
+++ b/modules/local/nf-core-modified/multiqc/main.nf
@@ -19,8 +19,6 @@ process MULTIQC {
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/multiqc:1.14--pyhdfd78af_0' :
         'taylorreiter/20221212-multiqc-sourmash:47808ae' }"
-    //container "${ workflow.containerEngine == 'docker' ? 'taylorreiter/20221212-multiqc-sourmash:47808ae':
-    //    '' }"
 
     input:
     // I changed the "stageAs:" option from ?/* to * to allow for the sourmash

--- a/modules/local/nf-core-modified/multiqc/main.nf
+++ b/modules/local/nf-core-modified/multiqc/main.nf
@@ -16,8 +16,11 @@ process MULTIQC {
         'quay.io/biocontainers/multiqc:1.13--pyhdfd78af_0' }"
     */
     conda "bioconda::multiqc=1.14" // This will not produce reports for the sourmash outputs as sourmash is not in the main branch of multiqc yet
-    container "${ workflow.containerEngine == 'docker' ? 'taylorreiter/20221212-multiqc-sourmash:47808ae':
-        '' }"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/multiqc:1.14--pyhdfd78af_0' :
+        'taylorreiter/20221212-multiqc-sourmash:47808ae' }"
+    //container "${ workflow.containerEngine == 'docker' ? 'taylorreiter/20221212-multiqc-sourmash:47808ae':
+    //    '' }"
 
     input:
     // I changed the "stageAs:" option from ?/* to * to allow for the sourmash


### PR DESCRIPTION
This PR enables singularity. Previously, the wget container i specified had an issue for singularity, so i changed it and now it runs on AWS EC2 with singularity and nextflow installed via conda. I also added a singularity profile for multiqc. like conda, the multiqc report won't include the sourmash outputs if it's run with singularity bc i'm using the singularity biocontainer, and the sourmash PRs aren't merged into multiqc yet. I'll update the pipeline ASAP when they are, but for now i thought it was better that it at least runs.
